### PR TITLE
Move images to clickhouse/ repo

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ on:
       organization:
         description: "DockerHub organization"
         required: false
-        default: "clickhouse"
+        default: "yandex"
 
 jobs:
   pre-release:
@@ -82,7 +82,12 @@ jobs:
             revision=${{ github.event.inputs.major }}.${{ github.event.inputs.minor }}.${{ github.event.inputs.patch }}
             repository=${{ github.repository }}
           tags: |
-            ${{ github.event.inputs.organization }}/jdbc-bridge:latest
-            ${{ github.event.inputs.organization }}/jdbc-bridge:${{ github.event.inputs.major }}
-            ${{ github.event.inputs.organization }}/jdbc-bridge:${{ github.event.inputs.major }}.${{ github.event.inputs.minor }}
-            ${{ github.event.inputs.organization }}/jdbc-bridge:${{ github.event.inputs.major }}.${{ github.event.inputs.minor }}.${{ github.event.inputs.patch }}
+            ${{ github.event.inputs.organization }}/clickhouse-jdbc-bridge:latest
+            ${{ github.event.inputs.organization }}/clickhouse-jdbc-bridge:${{ github.event.inputs.major }}
+            ${{ github.event.inputs.organization }}/clickhouse-jdbc-bridge:${{ github.event.inputs.major }}.${{ github.event.inputs.minor }}
+            ${{ github.event.inputs.organization }}/clickhouse-jdbc-bridge:${{ github.event.inputs.major }}.${{ github.event.inputs.minor }}.${{ github.event.inputs.patch }}
+            clickhouse/jdbc-bridge:latest
+            clickhouse/jdbc-bridge:${{ github.event.inputs.major }}
+            clickhouse/jdbc-bridge:${{ github.event.inputs.major }}.${{ github.event.inputs.minor }}
+            clickhouse/jdbc-bridge:${{ github.event.inputs.major }}.${{ github.event.inputs.minor }}.${{ github.event.inputs.patch }}
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ on:
       organization:
         description: "DockerHub organization"
         required: false
-        default: "yandex"
+        default: "clickhouse"
 
 jobs:
   pre-release:
@@ -82,7 +82,7 @@ jobs:
             revision=${{ github.event.inputs.major }}.${{ github.event.inputs.minor }}.${{ github.event.inputs.patch }}
             repository=${{ github.repository }}
           tags: |
-            ${{ github.event.inputs.organization }}/clickhouse-jdbc-bridge:latest
-            ${{ github.event.inputs.organization }}/clickhouse-jdbc-bridge:${{ github.event.inputs.major }}
-            ${{ github.event.inputs.organization }}/clickhouse-jdbc-bridge:${{ github.event.inputs.major }}.${{ github.event.inputs.minor }}
-            ${{ github.event.inputs.organization }}/clickhouse-jdbc-bridge:${{ github.event.inputs.major }}.${{ github.event.inputs.minor }}.${{ github.event.inputs.patch }}
+            ${{ github.event.inputs.organization }}/jdbc-bridge:latest
+            ${{ github.event.inputs.organization }}/jdbc-bridge:${{ github.event.inputs.major }}
+            ${{ github.event.inputs.organization }}/jdbc-bridge:${{ github.event.inputs.major }}.${{ github.event.inputs.minor }}
+            ${{ github.event.inputs.organization }}/jdbc-bridge:${{ github.event.inputs.major }}.${{ github.event.inputs.minor }}.${{ github.event.inputs.patch }}

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ JDBC bridge for ClickHouse®. It acts as a stateless proxy passing queries from 
     # create a network for ClickHouse and JDBC brigde, so that they can communicate with each other
     docker network create ch-net --attachable
     # start the two containers
-    docker run --rm -d --network ch-net --name jdbc-bridge --hostname jdbc-bridge yandex/clickhouse-jdbc-bridge
+    docker run --rm -d --network ch-net --name jdbc-bridge --hostname jdbc-bridge clickhouse/jdbc-bridge
     docker run --rm -d --network ch-net --name ch-server --hostname ch-server \
         --entrypoint /bin/bash yandex/clickhouse-server -c \
         "echo '<yandex><jdbc_bridge><host>jdbc-bridge</host><port>9019</port></jdbc_bridge></yandex>' \

--- a/docker/README.md
+++ b/docker/README.md
@@ -12,7 +12,7 @@ The latest tag points to the latest release from `master` branch. Branch tags li
 ```bash
 docker run -d --name ch-jdbc-bridge -p9019:9019 \
     -e MAVEN_REPO_URL="https://repo1.maven.org/maven2" \
-    -e JDBC_DRIVERS="org/mariadb/jdbc/mariadb-java-client/2.7.4/mariadb-java-client-2.7.4.jar,org/postgresql/postgresql/42.2.23/postgresql-42.2.23.jar" yandex/clickhouse-jdbc-bridge
+    -e JDBC_DRIVERS="org/mariadb/jdbc/mariadb-java-client/2.7.4/mariadb-java-client-2.7.4.jar,org/postgresql/postgresql/42.2.23/postgresql-42.2.23.jar" clickhouse/jdbc-bridge
 ```
 If you prefer to use JDBC drivers and named datasources on host, you can use the following commands:
 ```bash
@@ -24,7 +24,7 @@ wget -P datasources \
     https://raw.githubusercontent.com/ClickHouse/clickhouse-jdbc-bridge/master/misc/quick-start/jdbc-bridge/config/datasources/postgres13.json
 # please edit datasources/*.json to connect to your database servers
 docker run -d --name ch-jdbc-bridge -p9019:9019 -v `pwd`/drivers:/app/drivers \
-    -v `pwd`/datasources:/app/config/datasources yandex/clickhouse-jdbc-bridge
+    -v `pwd`/datasources:/app/config/datasources clickhouse/jdbc-bridge
 ```
 
 ### Configure ClickHouse server

--- a/misc/perf-test/docker-compose.yml
+++ b/misc/perf-test/docker-compose.yml
@@ -80,7 +80,7 @@ services:
         window: 60s
 
   jdbc-bridge:
-    image: yandex/clickhouse-jdbc-bridge
+    image: clickhouse/jdbc-bridge
     hostname: jdbc-bridge
     ports:
       - "9019:9019"

--- a/misc/quick-start/docker-compose.yml
+++ b/misc/quick-start/docker-compose.yml
@@ -63,7 +63,7 @@ services:
     restart: always
 
   jdbc-bridge:
-    image: yandex/clickhouse-jdbc-bridge:2.0
+    image: clickhouse/jdbc-bridge:2.0
     hostname: jdbc-bridge
     # In general you don't need to define any environment variable
     # Below are all default settings just for demonstration

--- a/src/test/java/ru/yandex/clickhouse/jdbcbridge/JdbcBridgeVerticleTest.java
+++ b/src/test/java/ru/yandex/clickhouse/jdbcbridge/JdbcBridgeVerticleTest.java
@@ -53,7 +53,7 @@ public class JdbcBridgeVerticleTest {
             .waitingFor(new LogMessageWaitStrategy().withRegEx(".*mysqld: ready for connections.*").withTimes(2)
                     .withStartupTimeout(Duration.of(60, SECONDS)));
 
-    private static final GenericContainer<?> jbServer = new GenericContainer<>("yandex/clickhouse-jdbc-bridge")
+    private static final GenericContainer<?> jbServer = new GenericContainer<>("clickhouse/jdbc-bridge")
             .withNetwork(sharedNetwork).withNetworkAliases("jdbc_bridge_server")
             .withFileSystemBind("target", "/build", BindMode.READ_WRITE)
             .withWorkingDirectory("/build/test-classes/sit/jdbc-bridge")


### PR DESCRIPTION
Hi @zhicwu, we are trying to migrate our docker images from yandex/ repo to clickhouse/ repo: https://github.com/ClickHouse/ClickHouse/pull/28656. I'm not sure how to do it for `yandex/clickhouse-jdbc-bridge`, probably my changes will break someones workflows. Maybe we can push jdbc-bridge to both `yandex/clickhouse-jdbc-bridge` and `clickhouse/jdbc-bridge`?