### PR TITLE
Remove hard-coded tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,12 +82,8 @@ jobs:
             revision=${{ github.event.inputs.major }}.${{ github.event.inputs.minor }}.${{ github.event.inputs.patch }}
             repository=${{ github.repository }}
           tags: |
-            ${{ github.event.inputs.organization }}/clickhouse-jdbc-bridge:latest
-            ${{ github.event.inputs.organization }}/clickhouse-jdbc-bridge:${{ github.event.inputs.major }}
-            ${{ github.event.inputs.organization }}/clickhouse-jdbc-bridge:${{ github.event.inputs.major }}.${{ github.event.inputs.minor }}
-            ${{ github.event.inputs.organization }}/clickhouse-jdbc-bridge:${{ github.event.inputs.major }}.${{ github.event.inputs.minor }}.${{ github.event.inputs.patch }}
-            clickhouse/jdbc-bridge:latest
-            clickhouse/jdbc-bridge:${{ github.event.inputs.major }}
-            clickhouse/jdbc-bridge:${{ github.event.inputs.major }}.${{ github.event.inputs.minor }}
-            clickhouse/jdbc-bridge:${{ github.event.inputs.major }}.${{ github.event.inputs.minor }}.${{ github.event.inputs.patch }}
+            ${{ github.event.inputs.organization }}/jdbc-bridge:latest
+            ${{ github.event.inputs.organization }}/jdbc-bridge:${{ github.event.inputs.major }}
+            ${{ github.event.inputs.organization }}/jdbc-bridge:${{ github.event.inputs.major }}.${{ github.event.inputs.minor }}
+            ${{ github.event.inputs.organization }}/jdbc-bridge:${{ github.event.inputs.major }}.${{ github.event.inputs.minor }}.${{ github.event.inputs.patch }}
 


### PR DESCRIPTION
Only needs to push image to `clickhouse/jdbc-bridge` as `yandex/clickhouse-jdbc-bridge` is deprecated.