### PR TITLE
Fix incorrect JAR version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN apt-get update \
 	&& DEBIAN_FRONTEND=noninteractive apt-get install -y --allow-unauthenticated apache2-utils \
 		apt-transport-https curl htop iftop iptraf iputils-ping jq lsof net-tools tzdata wget \
 	&& apt-get clean \
-	&& if [ "$revision" = "latest" ] ; then export JDBC_BRIDGE_VERSION=$(curl -s https://repo1.maven.org/maven2/ru/yandex/clickhouse/clickhouse-jdbc-bridge/maven-metadata.xml | grep '<latest>' | sed -e 's|^.*>\(.*\)<.*$|\1|'); else export JDBC_BRIDGE_VERSION=${revision}; fi \
+	&& if [ "$revision" = "latest" ] ; then export JDBC_BRIDGE_VERSION=$(curl -s https://repo1.maven.org/maven2/com/clickhouse/clickhouse-jdbc-bridge/maven-metadata.xml | grep '<latest>' | sed -e 's|^.*>\(.*\)<.*$|\1|'); else export JDBC_BRIDGE_VERSION=${revision}; fi \
 	&& wget -P $JDBC_BRIDGE_HOME/drivers \
 		https://repo1.maven.org/maven2/com/clickhouse/clickhouse-jdbc/0.3.2-patch8/clickhouse-jdbc-0.3.2-patch8-all.jar \
 		https://repo1.maven.org/maven2/org/mariadb/jdbc/mariadb-java-client/3.0.4/mariadb-java-client-3.0.4.jar \


### PR DESCRIPTION
Fixes https://github.com/ClickHouse/clickhouse-jdbc-bridge/issues/155

```
 docker run -it clickhouse/clickhouse-jdbc-bridge:2.1.1 bash
root@d32167bf7d9a:/app# ls -al *.jar
-rw-r--r-- 1 root root 10740290 Apr 18 23:08 clickhouse-jdbc-bridge-2.1.0-shaded.jar
lrwxrwxrwx 1 root root       44 Jul 27 02:13 clickhouse-jdbc-bridge-shaded.jar -> /app/clickhouse-jdbc-bridge-2.1.0-shaded.jar
```